### PR TITLE
Adding new django beanstalkd decorator

### DIFF
--- a/django_beanstalkd/__init__.py
+++ b/django_beanstalkd/__init__.py
@@ -3,6 +3,6 @@ Django Beanstalk Interface
 """
 from .client import BeanstalkClient, DataBeanstalkClient
 from .connection import connect_beanstalkd
-from .decorators import backoff_beanstalk_job, beanstalk_job, data_beanstalk_job
+from .decorators import backoff_beanstalk_job, beanstalk_job, data_beanstalk_job, retry_data_beanstalk_job
 from .errors import BeanstalkError, BeanstalkRetryError
 from .models import JobData


### PR DESCRIPTION
I created a new decorator that will allow retries as well as store data (in case you need to send data to a job that might be longer than a "small" string).

This is used in `handl` but can be used in other places.